### PR TITLE
Remove dependency on Hyrax::Noid

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ The name is a cross between “Hydrus”, the legacy self-deposit application in
 Please be aware that the initial use of Hyrax in this repository is not a determination of platform decision related to Hyku/Hyrax, but is being used to capture initial work related to authentication and integration with existing SUL-DLSS projects.
 
 The state of the `master` branch of this repository should generally stay at the post `generate hyrax:install` step but pre `db:migrate` step.
+
+# Work Types
+
+*Note:* when generating new work types in this application, it is required to add
+
+```
+include Suri::Druid
+```
+
+to the model in order to mint the ID as a DRUID instead of a Fedora UUID.

--- a/app/services/suri/druid.rb
+++ b/app/services/suri/druid.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Suri
+  # Mix this module into generated work types in order to have IDs minted
+  # as a druid.
+  module Druid
+
+    ## This overrides the default behavior, which is to ask Fedora for an id
+    # @see ActiveFedora::Persistence.assign_id
+    def assign_id
+      service.mint
+    end
+
+    private
+
+    def service
+      @service ||= Suri::Minter.new
+    end
+  end
+end

--- a/app/services/suri/druid.rb
+++ b/app/services/suri/druid.rb
@@ -4,7 +4,6 @@ module Suri
   # Mix this module into generated work types in order to have IDs minted
   # as a druid.
   module Druid
-
     ## This overrides the default behavior, which is to ask Fedora for an id
     # @see ActiveFedora::Persistence.assign_id
     def assign_id

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -59,13 +59,13 @@ Hyrax.config do |config|
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens
   # config.enable_noids = true
+  config.enable_noids = false
 
   # Template for your repository's NOID IDs
   # config.noid_template = ".reeddeeddk"
 
   # Use the database-backed minter class
   # config.noid_minter_class = ActiveFedora::Noid::Minter::Db
-  config.noid_minter_class = Suri::Minter
   
   # Store identifier minter's state in a file for later replayability
   # config.minter_statefile = '/tmp/minter-state'


### PR DESCRIPTION
This removes Hyrax::Noid through `config.enable_noid = false` and adds a requirement that `include Suri::Druid` be added to any model in which we want a DRUID instead of a Fedora UUID.