### PR TITLE
Add missing error module and fix typo

### DIFF
--- a/app/services/suri/minter.rb
+++ b/app/services/suri/minter.rb
@@ -15,7 +15,7 @@ module Suri
 
     def retrieve_druid
       return druid if valid_druid?
-      raise Hydrox::SuriInvalidDruidReturned, "Invalid druid: #{driud}"
+      raise Hydrox::SuriInvalidDruidReturned, "Invalid druid: #{druid}"
     end
 
     def druid

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,11 @@
+# A custom exceptions class to provide specific Hydrox::Exceptions
+module Hydrox
+  # A Timeout error raised when the connection to SURI timesout
+  class SuriTimeoutError < StandardError; end
+
+  class SuriAuthenticationError < StandardError; end
+
+  class SuriException < StandardError; end
+
+  class SuriInvalidDruidReturned < StandardError; end
+end


### PR DESCRIPTION
Error module was not included in a prior PR apparently. This also fixes a typo in one of the error calls.