### PR TITLE
Remove deprecated route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
   resources :welcome, only: 'index'
   root 'hyrax/homepage#index'
   curation_concerns_basic_routes
-  curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
Prevent this error:

```
DEPRECATION WARNING: #curation_concerns_embargo_management is deprecated and has no effect. It will be removed in Hyrax 3.0. (called from block in <top (required)> at /home/travis/build/sul-dlss/hydrox/config/routes.rb:17) (1 times);
```