### PR TITLE
Remove asset/ from configuration for masthead

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -113,7 +113,7 @@ Hyrax.config do |config|
   #
   # The banner image. Should be 5000px wide by 1000px tall
   # config.banner_image = 'https://cloud.githubusercontent.com/assets/92044/18370978/88ecac20-75f6-11e6-8399-6536640ef695.jpg'
-  config.banner_image = 'assets/banner-stanford_oval-panorama.jpg'
+  config.banner_image = 'banner-stanford_oval-panorama.jpg'
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately


### PR DESCRIPTION
Removes the 'asset/' from the path to the masthead image which is broken in display.