### PR TITLE
Rescue the rake task to avoid production build failure

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -78,3 +78,7 @@ Style/SymbolArray:
   EnforcedStyle: brackets
   Exclude:
     - 'app/controllers/catalog_controller.rb'
+
+Lint/HandleExceptions:
+  Exclude:
+    - 'tasks/hydrox_dev.rake'

--- a/tasks/hydrox_dev.rake
+++ b/tasks/hydrox_dev.rake
@@ -1,27 +1,30 @@
-require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+begin
+  require 'rspec/core/rake_task'
+  require 'rubocop/rake_task'
 
-desc 'Run style checker'
+  desc 'Run style checker'
 
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.fail_on_error = true
-end
-
-RSpec::Core::RakeTask.new(:spec)
-
-desc 'Spin up test servers and run specs'
-task :spec_with_app_load do
-  require 'solr_wrapper'   # necessary for rake_support to work
-  require 'fcrepo_wrapper' # necessary for rake_support to work
-  require 'active_fedora/rake_support'
-
-  with_test_server do
-    Rake::Task['spec'].invoke
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.fail_on_error = true
   end
-end
 
-desc 'Run continuous integration tests'
-task ci: [:rubocop] do
-  puts 'running continuous integration'
-  Rake::Task['spec_with_app_load'].invoke
+  RSpec::Core::RakeTask.new(:spec)
+
+  desc 'Spin up test servers and run specs'
+  task :spec_with_app_load do
+    require 'solr_wrapper'   # necessary for rake_support to work
+    require 'fcrepo_wrapper' # necessary for rake_support to work
+    require 'active_fedora/rake_support'
+
+    with_test_server do
+      Rake::Task['spec'].invoke
+    end
+  end
+
+  desc 'Run continuous integration tests'
+  task ci: [:rubocop] do
+    puts 'running continuous integration'
+    Rake::Task['spec_with_app_load'].invoke
+  end
+rescue LoadError
 end


### PR DESCRIPTION
Wrap the dev rake task in a rescue block so that it doesn't cause the production EB build to fail.