### PR TITLE
Explicitly sets path for supervisord cmd

### DIFF
--- a/.ebextensions/04_fastcgi.config
+++ b/.ebextensions/04_fastcgi.config
@@ -30,4 +30,4 @@ commands:
   01_fastcgi:
     command: easy_install supervisor
   02_supervise_shibauth_and_shibrespond:
-    command: supervisord -c /etc/supervisord.conf
+    command: /usr/local/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
Some deploys were failing to find the `supervisord` cmd so this sets the path for it explicitly.