### PR TITLE
Fix bad margin causing problems with footer

### DIFF
--- a/app/assets/stylesheets/sul_footer.css
+++ b/app/assets/stylesheets/sul_footer.css
@@ -4,7 +4,7 @@
     -webkit-box-shadow: 0 4px 8px -8px rgba(0, 0, 0, 0.2) inset;
     box-shadow: 0 4px 8px -8px rgba(0, 0, 0, 0.2) inset;
     clear: both;
-    margin-top: -200px;
+    margin-top: 20px;
     min-height: 200px;
     padding: 0 !important;
     position: relative


### PR DESCRIPTION
This margin was wrong and causing the footer to cover the login form. This moves it back into appropriate position and provides a bit of space at the bottom of the login form.