### PR TITLE
Set login referrer to /dashboard

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,29 @@
+<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+  <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+  <% if user_signed_in? %>
+    <li>
+      <%= render_notifications(user: current_user) %>
+    </li>
+    <li class="dropdown">
+      <%= link_to hyrax.dashboard_profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path %></li>
+
+        <li class="divider"></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+      </ul>
+    </li><!-- /.btn-group -->
+  <% else %>
+    <li>
+      <%= link_to main_app.new_user_session_path(referrer: '/dashboard') do %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> <%= t("hyrax.toolbar.profile.login") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
This sets the referrer to /dashboard on shibboleth login for the proper return end-point.