### PR TITLE
[WIP] Don't use shib for local development authentication

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,6 +19,7 @@ Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
     - 'config/initializers/*'
+    - 'config/routes.rb'
     - 'db/schema.rb'
     - 'spec/**/*'
 
@@ -110,4 +111,3 @@ Lint/HandleExceptions:
 Lint/RescueWithoutErrorClass:
   Exclude:
     - 'db/migrate/*'
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   private
 
   def after_sign_out_path_for(*)
-    '/Shibboleth.sso/Logout' unless Rails.env.development?
+    return '/Shibboleth.sso/Logout' unless Rails.env.development?
     root_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   private
 
   def after_sign_out_path_for(*)
-    '/Shibboleth.sso/Logout'
+    '/Shibboleth.sso/Logout' unless Rails.env.development?
+    root_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   private
 
   def after_sign_out_path_for(*)
-    return '/Shibboleth.sso/Logout' unless Rails.env.development?
+    return '/Shibboleth.sso/Logout' unless Rails.env.development? || Rails.env.test?
     root_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       match 'shib/logout' => 'devise/sessions#destroy', :as => :destroy_user_session, :via => Devise.mappings[:user].sign_out_via
     end
   end
-  
+
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,12 +7,16 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users, skip: [:registrations, :passwords, :sessions]
-  devise_scope :user do
-    get 'shib/login' => 'login#login', as: :new_user_session
-    match 'shib/logout' => 'devise/sessions#destroy', :as => :destroy_user_session, :via => Devise.mappings[:user].sign_out_via
+  if Rails.env.development?
+    devise_for :users
+  else
+    devise_for :users, skip: [:registrations, :passwords, :sessions]
+    devise_scope :user do
+      get 'shib/login' => 'login#login', as: :new_user_session
+      match 'shib/logout' => 'devise/sessions#destroy', :as => :destroy_user_session, :via => Devise.mappings[:user].sign_out_via
+    end
   end
-
+  
   mount Qa::Engine => '/authorities'
   mount Hyrax::Engine, at: '/'
   resources :welcome, only: 'index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  if Rails.env.development?
+  if Rails.env.development? || Rails.env.test?
     devise_for :users
   else
     devise_for :users, skip: [:registrations, :passwords, :sessions]


### PR DESCRIPTION
This wraps the shibboleth specific login/logout so that local password logins can be used during development