### PR TITLE
Adjust nginx config to set Remote-User response

### DIFF
--- a/.ebextensions/07_load_nginx_conf.config
+++ b/.ebextensions/07_load_nginx_conf.config
@@ -60,27 +60,12 @@ files:
           }
 
           location /shib/login {
-               include shib_clear_headers;
-               shib_request /shibauthorizer;
-               shib_request_use_headers on;
-               proxy_pass http://my_app;
-           }
-
+            shib_request /shibauthorizer;
+            shib_request_use_headers on;
+            more_clear_input_headers 'Remote-User';
+            proxy_pass http://my_app;
+          }
       }
-
-  /etc/nginx/shib_clear_headers:
-    content: |
-      more_clear_input_headers
-        suAffiliation
-        REMOTE_USER;
-
-  /etc/nginx/shib_fastcgi_params:
-    content: |
-      shib_request_set $shib_remote_user $upstream_http_variable_remote_user;
-      fastcgi_param REMOTE_USER $shib_remote_user;
-
-      # shib_request_set $shib_affliation $upstream_http_variable_suaffiliation;
-      # fastcgi_param suAffiliation $shib_affiliation;
 
 container_commands:
   01_add_shibd_user_to_nginx_group:


### PR DESCRIPTION
We only need to clear the `Remote-User` header for the app. This gets converted to `HTTP_REMOTE_USER` via puma for requests to `/shib/login` endpoints