### PR TITLE
Add i18n translations for Stanford Footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,10 +7,10 @@
       <div id="sul-footer-links" class="span2">
         <ul>
           <li><a href="http://library.stanford.edu">Stanford University Libraries</a></li>
-          <li><a href="http://library.stanford.edu/hours">Hours &amp; locations</a></li>
-          <li> <a href="http://library.stanford.edu/myawrap.html">My Account</a></li>
-          <li> <a href="http://library.stanford.edu/ask">Ask us</a></li>
-          <li> <a href="http://library.stanford.edu/opt-out">Opt out of analytics</a></li>
+          <li><a href="http://library.stanford.edu/hours"><%= t('hydrox.footer.hours_and_locations') %></a></li>
+          <li> <a href="http://library.stanford.edu/myawrap.html"><%= t('hydrox.footer.my_account') %></a></li>
+          <li> <a href="http://library.stanford.edu/ask"><%= t('hydrox.footer.ask_us') %></a></li>
+          <li> <a href="http://library.stanford.edu/opt-out"><%= t('hydrox.footer.opt_out_of_analytics') %></a></li>
         </ul>
       </div>
     </div>
@@ -29,11 +29,11 @@
       <!-- #bottom-logo end -->
       <div id="bottom-text" class="span10">
         <ul>
-          <li class="home"><a href="http://www.stanford.edu">SU Home</a></li>
-          <li class="maps alt"><a href="http://visit.stanford.edu/plan/maps.html">Maps &amp; Directions</a></li>
-          <li class="search-stanford"><a href="http://www.stanford.edu/search/">Search Stanford</a></li>
-          <li class="terms alt"><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
-          <li class="emergency-info"><a href="http://emergency.stanford.edu">Emergency Info</a></li>
+          <li class="home"><a href="http://www.stanford.edu"><%= t('hydrox.footer.home') %></a></li>
+          <li class="maps alt"><a href="http://visit.stanford.edu/plan/maps.html"><%= t('hydrox.footer.maps_and_directions') %></a></li>
+          <li class="search-stanford"><a href="http://www.stanford.edu/search/"><%= t('hydrox.footer.search') %></a></li>
+          <li class="terms alt"><a href="http://www.stanford.edu/site/terms.html"><%= t('hydrox.footer.terms_of_use') %></a></li>
+          <li class="emergency-info"><a href="http://emergency.stanford.edu"><%= t('hydrox.footer.emergency') %></a></li>
         </ul>
       </div> <!-- .bottom-text end -->
       <div class="clear"></div>

--- a/config/locales/footer.en.yml
+++ b/config/locales/footer.en.yml
@@ -1,0 +1,12 @@
+en:
+  hydrox:
+    footer:
+      ask_us: Ask Us
+      emergency: Emergency Info
+      home: SU Home
+      hours_and_locations: Hours & Locations
+      maps_and_directions: Maps & Directions
+      my_account: My Account
+      opt_out_of_analytics: Opt Out of Analytics
+      search: Search Stanford
+      terms_of_use: Terms of Use

--- a/config/locales/footer.es.yml
+++ b/config/locales/footer.es.yml
@@ -1,0 +1,12 @@
+es:
+  hydrox:
+    footer:
+      ask_us: Preguntanos
+      emergency: Información de Emergencia
+      home: SU Home
+      hours_and_locations: Horas & Ubicaciones
+      maps_and_directions: Mapas y Direcciones
+      my_account: Mi Cuenta
+      opt_out_of_analytics: Exclusión de Analytics
+      search: Buscar Stanford
+      terms_of_use: Términos de Uso

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -50,6 +50,3 @@ en:
     account_name:           "My Institution Account Id"
     directory:
       suffix:               "@example.org"
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
-      service_html: A service of <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Project Hydra</a>.

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -50,6 +50,3 @@ es:
     account_name:           "Mi identificador de cuenta institucional"
     directory:
       suffix:               "@example.org"
-    footer:
-      copyright_html: "<strong>Copyright &copy; 2017 Proyecto Hydra</strong> bajo licencia de Apache, Version 2.0"
-      service_html: Un servicio de <a href="http://projecthydra.org/" class="navbar-link" target="_blank">Proyecto Hydra</a>.


### PR DESCRIPTION
- [x] Switches raw text to translations
- [x] Adds hydrox `footer.en.yml` and `footer.es.yml` for initial translations

Addresses: #94 